### PR TITLE
Fix server starting with missing keys by importing the example_processors

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ To start the web server, simply run:
 
 ```
 source activate tranx
-PYTHONPATH=../ python app.py --config_file config/server/config_py3.json
+PYTHONPATH=. python server/app.py --config_file config/server/config_py3.json
 ```
 
 This will start a web server at port 8081 with ATIS/GEO/CoNaLa datasets.

--- a/components/standalone_parser.py
+++ b/components/standalone_parser.py
@@ -11,6 +11,9 @@ from model.parser import Parser
 from model.reconstruction_model import Reconstructor
 from model.paraphrase import ParaphraseIdentificationModel
 from datasets.conala import example_processor
+from datasets.atis import example_processor
+from datasets.geo import example_processor
+from datasets.django import example_processor
 
 if six.PY3:
     pass

--- a/config/server/config_py3.json
+++ b/config/server/config_py3.json
@@ -3,18 +3,28 @@
     "parser": "default_parser",
     "example_processor": "atis_example_processor",
     "model_path": "data/pretrained_models/atis.bin",
+    "reranker_path": "best_pretrained_models/reranker.conala.vocab.src_freq3.code_freq3.mined_100000.intent_count100k_topk1_temp5.bin",
     "beam_size": 5
   },
   "geo": {
     "parser": "default_parser",
     "example_processor": "geo_example_processor",
     "model_path": "data/pretrained_models/geo.bin",
+    "reranker_path": "best_pretrained_models/reranker.conala.vocab.src_freq3.code_freq3.mined_100000.intent_count100k_topk1_temp5.bin",
     "beam_size": 5
   },
   "conala": {
     "parser": "default_parser",
     "example_processor": "conala_example_processor",
     "model_path": "data/pretrained_models/conala.bin",
+    "reranker_path": "best_pretrained_models/reranker.conala.vocab.src_freq3.code_freq3.mined_100000.intent_count100k_topk1_temp5.bin",
+    "beam_size": 15
+  },
+  "django": {
+    "parser": "default_parser",
+    "example_processor": "django_example_processor",
+    "model_path": "data/pretrained_models/django.bin",
+    "reranker_path": "best_pretrained_models/reranker.conala.vocab.src_freq3.code_freq3.mined_100000.intent_count100k_topk1_temp5.bin",
     "beam_size": 15
   }
 }

--- a/datasets/atis/data_process/utils.py
+++ b/datasets/atis/data_process/utils.py
@@ -43,7 +43,7 @@ def sort_entity_list(e_list):
   return sorted([e.split('\t') for e in set(['\t'.join((n, t)) for n, t in e_list])], key=lambda x: x[1])
 
 
-def read_iata_mapping(e2m_dict, e2type_dict, fn='data/atis/iata.txt'):
+def read_iata_mapping(e2m_dict, e2type_dict, fn='data/atis/ci_ap_mapping.txt'):
   # IATA code crawled from wikipedia
   with codecs.open(fn, encoding='utf-8') as f_in:
     for l in filter(lambda x: len(x) > 0, map(lambda x: x.strip().lower(), f_in.read().split('\n'))):

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,0 +1,8 @@
+flask
+astor==0.7.1
+records
+pymongo
+numpy
+nltk
+xgboost
+python-rex


### PR DESCRIPTION
Fix server starting with missing keys by importing the example_procesors so that they are registered, and include requirements.txt for those who are more comfortable with it instead of conda like me (if you want to keep only conda I can delete it)

Also update README.txt to run it from project root, causing less confusion for users

This should close #35 
