### PR TITLE
Setup scripts

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,70 @@
+[metadata]
+name = tranX
+version = 0.2.0
+description = TranX
+author = Pengcheng Yin, Frank Xu, Graham Neubig
+long-description = file: README.md
+long-description-content-type = text/markdown; charset=UTF-8
+url = https://github.com/pcyin/tranX
+project-urls =
+    Documentation = https://github.com/pcyin/tranX
+    Demo = http://pcyin.me/tranX
+license = Apache Software License
+classifiers =
+    License :: OSI Approved :: Apache Software License
+    Programming Language :: Python
+
+[options]
+zip_safe = False
+packages = find:
+py_modules =
+    exp
+    evaluation
+include_package_data = True
+package_dir = # No base package
+    = .
+python_requires = >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*
+install_requires =
+    nltk
+scripts =
+# These don't work as they are identically named and as they don't invoke exp.py using "python -m exp"
+#    scripts/atis/train.sh
+#    scripts/atis/test.sh
+#    scripts/conala/train.sh
+#    scripts/conala/test.sh
+#    scripts/django/train.sh
+#    scripts/django/test.sh
+#    scripts/geo/train.sh
+#    scripts/geo/test.sh
+#    scripts/jobs/train.sh
+#    scripts/jobs/test.sh
+#    scripts/wikisql/test.sh
+#    scripts/wikisql/train.sh
+
+[options.packages.find]
+where = .
+exclude =
+    build
+    config
+    data
+    decodes
+    dist
+    doc
+    logs
+    saved_models
+    scripts
+
+[options.entry_points]
+console_scripts =
+# This doesn't work because there is no main function
+#    tranx = exp:main
+
+[aliases]
+dists = bdist_wheel
+
+[bdist_wheel]
+universal = 1
+
+[devpi:upload]
+no-vcs = 1
+formats = bdist_wheel

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,12 @@
+import sys
+
+from pkg_resources import VersionConflict, require
+from setuptools import setup
+
+try:
+    require('setuptools>=38.3')
+except VersionConflict:
+    print("Error: version of setuptools is too old (<38.3)!")
+    sys.exit(1)
+
+setup()


### PR DESCRIPTION
Hello,

I made setup scripts for TranX so it can be installed into Python environments.
I didn't find any version number other than 0.1.0 for a very old Git tag, so I used 0.2.0.

As there is no base package, the Python modules and packages will be installed into the site-packages root. It would be a good idea to move everything into a base package.
Also, I could not configure any scripts as the Python scripts under scripts/ don't use the "python -m" syntax, so they don't work outside the source tree, and all of them are named either train.sh or test.sh so there are name collisions when they are put into the environment's bin directory. I also could not use entry_points.console_scripts as exp.py doesn't have a "main" function.

If you're fine with me doing these additional changes, I can make another PR.